### PR TITLE
get real caller from ES for events

### DIFF
--- a/apps/api/src/endpoints/data-integration/data-integration.service.ts
+++ b/apps/api/src/endpoints/data-integration/data-integration.service.ts
@@ -144,7 +144,7 @@ export class DataIntegrationService {
 
     const txHashes = filteredEvents.map(event => event.txnId);
 
-    const transactions = await this.indexerService.getTxDetails(txHashes);
+    const transactions = await this.getTxDetailsInBatches(txHashes, 200);
 
     const txToCallerMap = new Map<string, string>(
       transactions.map(transaction => [transaction.txHash, transaction.sender])
@@ -158,5 +158,20 @@ export class DataIntegrationService {
         }
       }
     }
+  }
+
+  private async getTxDetailsInBatches(txHashes: string[], batchSize: number) {
+    let transactions: any[] = [];
+    let start = 0;
+    while (start < txHashes.length) {
+      const txHashesBatch = txHashes.slice(start, start + batchSize);
+
+      const transactionsBatch = await this.indexerService.getTxDetails(txHashesBatch);
+
+      transactions.push(...transactionsBatch);
+      start += batchSize;
+    }
+
+    return transactions;
   }
 }

--- a/apps/api/src/endpoints/data-integration/data-integration.service.ts
+++ b/apps/api/src/endpoints/data-integration/data-integration.service.ts
@@ -4,7 +4,7 @@ import {
   IndexerService, JoinExitEvent, LatestBlockResponse,
   MultiversXApiService, PairResponse, SwapEvent, XExchangeService,
 } from "@mvx-monorepo/common";
-import { AddressUtils, OriginLogger } from "@multiversx/sdk-nestjs-common";
+import { AddressUtils, BatchUtils, OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { IProviderService } from "@mvx-monorepo/common/providers/interface";
 import { GeneralEvent } from "@mvx-monorepo/common/providers/entities/general.event";
 import { OneDexService } from "@mvx-monorepo/common/providers";
@@ -162,14 +162,12 @@ export class DataIntegrationService {
 
   private async getTxDetailsInBatches(txHashes: string[], batchSize: number) {
     const transactions: any[] = [];
-    let start = 0;
-    while (start < txHashes.length) {
-      const txHashesBatch = txHashes.slice(start, start + batchSize);
+    const txHashesBatches = BatchUtils.splitArrayIntoChunks(txHashes, batchSize);
 
+    for (const txHashesBatch of txHashesBatches) {
       const transactionsBatch = await this.indexerService.getTxDetails(txHashesBatch);
 
       transactions.push(...transactionsBatch);
-      start += batchSize;
     }
 
     return transactions;

--- a/apps/api/src/endpoints/data-integration/data-integration.service.ts
+++ b/apps/api/src/endpoints/data-integration/data-integration.service.ts
@@ -161,7 +161,7 @@ export class DataIntegrationService {
   }
 
   private async getTxDetailsInBatches(txHashes: string[], batchSize: number) {
-    let transactions: any[] = [];
+    const transactions: any[] = [];
     let start = 0;
     while (start < txHashes.length) {
       const txHashesBatch = txHashes.slice(start, start + batchSize);

--- a/apps/api/src/endpoints/data-integration/data-integration.service.ts
+++ b/apps/api/src/endpoints/data-integration/data-integration.service.ts
@@ -142,7 +142,7 @@ export class DataIntegrationService {
   private async updateEventsCaller(events: ({ block: Block } & (SwapEvent | JoinExitEvent))[]) {
     const filteredEvents = events.filter(event => AddressUtils.isSmartContractAddress(event.maker));
 
-    const txHashes = filteredEvents.map(event => event.txnId)
+    const txHashes = filteredEvents.map(event => event.txnId);
 
     const transactions = await this.indexerService.getTxDetails(txHashes);
 
@@ -158,6 +158,5 @@ export class DataIntegrationService {
         }
       }
     }
-    console.log(txToCallerMap)
   }
 }

--- a/apps/api/src/endpoints/data-integration/data-integration.service.ts
+++ b/apps/api/src/endpoints/data-integration/data-integration.service.ts
@@ -4,7 +4,7 @@ import {
   IndexerService, JoinExitEvent, LatestBlockResponse,
   MultiversXApiService, PairResponse, SwapEvent, XExchangeService,
 } from "@mvx-monorepo/common";
-import { OriginLogger } from "@multiversx/sdk-nestjs-common";
+import { AddressUtils, OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { IProviderService } from "@mvx-monorepo/common/providers/interface";
 import { GeneralEvent } from "@mvx-monorepo/common/providers/entities/general.event";
 import { OneDexService } from "@mvx-monorepo/common/providers";
@@ -83,6 +83,8 @@ export class DataIntegrationService {
       allEvents.push(...event);
     }
 
+    await this.updateEventsCaller(allEvents);
+
     const sortedEvents = allEvents.sort((a, b) => {
       if (a.block.blockTimestamp !== b.block.blockTimestamp) {
         return a.block.blockTimestamp - b.block.blockTimestamp;
@@ -135,5 +137,27 @@ export class DataIntegrationService {
       });
     }
     return events;
+  }
+
+  private async updateEventsCaller(events: ({ block: Block } & (SwapEvent | JoinExitEvent))[]) {
+    const filteredEvents = events.filter(event => AddressUtils.isSmartContractAddress(event.maker));
+
+    const txHashes = filteredEvents.map(event => event.txnId)
+
+    const transactions = await this.indexerService.getTxDetails(txHashes);
+
+    const txToCallerMap = new Map<string, string>(
+      transactions.map(transaction => [transaction.txHash, transaction.sender])
+    );
+
+    for (const event of events) {
+      if (AddressUtils.isSmartContractAddress(event.maker)) {
+        const callerFromMap = txToCallerMap.get(event.txnId);
+        if (callerFromMap) {
+          event.maker = callerFromMap;
+        }
+      }
+    }
+    console.log(txToCallerMap)
   }
 }

--- a/libs/common/src/providers/onedex/onedex.service.ts
+++ b/libs/common/src/providers/onedex/onedex.service.ts
@@ -109,7 +109,7 @@ export class OneDexService implements IProviderService {
   public async getPairsMetadata(): Promise<any[]> {
     return await this.cacheService.getOrSet(
       CacheInfo.OneDexPairsMetadata().key,
-      () => this.getPairsMetadataRaw(),
+      async () => await this.getPairsMetadataRaw(),
       CacheInfo.OneDexPairsMetadata().ttl,
     );
   }

--- a/libs/common/src/providers/xexchange/xexchange.service.ts
+++ b/libs/common/src/providers/xexchange/xexchange.service.ts
@@ -80,7 +80,7 @@ export class XExchangeService implements IProviderService {
   public async getPairsMetadata(): Promise<PairMetadata[]> {
     return await this.cacheService.getOrSet(
       CacheInfo.PairsMetadata().key,
-      () => this.getPairsMetadataRaw(),
+      async () => await this.getPairsMetadataRaw(),
       CacheInfo.PairsMetadata().ttl,
     );
   }
@@ -115,7 +115,7 @@ export class XExchangeService implements IProviderService {
   public async getPairFeePercent(pairAddress: string): Promise<number> {
     return await this.cacheService.getOrSet(
       CacheInfo.PairFeePercent(pairAddress).key,
-      () => this.getPairFeePercentRaw(pairAddress),
+      async () => await this.getPairFeePercentRaw(pairAddress),
       CacheInfo.PairFeePercent(pairAddress).ttl,
     );
   }

--- a/libs/common/src/providers/xexchange/xexchange.service.ts
+++ b/libs/common/src/providers/xexchange/xexchange.service.ts
@@ -200,6 +200,18 @@ export class XExchangeService implements IProviderService {
             this.logger.error(`Unknown event topic ${event.topics[0]}. Event: ${JSON.stringify(event)}`);
         }
       }
+
+    }
+    const swapEvents = events.filter(event => event instanceof XExchangeSwapEvent && (new Address(event.caller)).isContractAddress());
+    const txHashes = swapEvents.map(event => event.txHash)
+    const txCallerPairs = await this.indexerService.getTxCallerPairs(txHashes)
+    for (const event of events) {
+      if (event instanceof XExchangeSwapEvent && (new Address(event.caller)).isContractAddress()) {
+        const matchingPair = txCallerPairs.find(pair => pair.tx === event.txHash);
+        if (matchingPair) {
+          event.caller = matchingPair.caller;
+        }
+      }
     }
 
     return events;

--- a/libs/common/src/providers/xexchange/xexchange.service.ts
+++ b/libs/common/src/providers/xexchange/xexchange.service.ts
@@ -16,7 +16,7 @@ import { PairMetadata } from "../entities";
 import { CacheService } from "@multiversx/sdk-nestjs-cache";
 import BigNumber from "bignumber.js";
 import { IndexerService } from "../../services/indexer";
-import { AddressUtils, BinaryUtils, OriginLogger } from "@multiversx/sdk-nestjs-common";
+import { BinaryUtils, OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { PAIR_EVENTS } from "@multiversx/sdk-exchange";
 import { MultiversXApiService } from "../../services/multiversx.api";
 import { PerformanceProfiler } from "@multiversx/sdk-nestjs-monitoring";
@@ -201,25 +201,6 @@ export class XExchangeService implements IProviderService {
         }
       }
 
-    }
-
-    const filteredEvents = events.filter(event => AddressUtils.isSmartContractAddress(event.caller));
-
-    const txHashes = filteredEvents.map(event => event.txHash)
-
-    const transactions = await this.indexerService.getTxDetails(txHashes);
-
-    const txToCallerMap = new Map<string, string>(
-      transactions.map(transaction => [transaction.txHash, transaction.sender])
-    );
-
-    for (const event of events) {
-      if (AddressUtils.isSmartContractAddress(event.caller)) {
-        const callerFromMap = txToCallerMap.get(event.txHash);
-        if (callerFromMap) {
-          event.caller = callerFromMap;
-        }
-      }
     }
 
     return events;

--- a/libs/common/src/providers/xexchange/xexchange.service.ts
+++ b/libs/common/src/providers/xexchange/xexchange.service.ts
@@ -200,7 +200,6 @@ export class XExchangeService implements IProviderService {
             this.logger.error(`Unknown event topic ${event.topics[0]}. Event: ${JSON.stringify(event)}`);
         }
       }
-
     }
 
     return events;

--- a/libs/common/src/services/indexer/indexer.service.ts
+++ b/libs/common/src/services/indexer/indexer.service.ts
@@ -99,14 +99,21 @@ export class IndexerService {
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
   public async getTxDetails(txHashes: string[]) {
-    const query = ElasticQuery.create()
-      .withPagination({ from: 0, size: 10000 })
-      .withMustCondition([
-        QueryType.Should(txHashes.map(txHash => new MatchQuery("_id", txHash))),
-      ]);
+    try {
+      const query = ElasticQuery.create()
+        .withPagination({ from: 0, size: 10000 })
+        .withMustCondition([
+          QueryType.Should(txHashes.map(txHash => new MatchQuery("_id", txHash))),
+        ]);
 
-    const transactions = await this.elasticService.getList('operations', 'txHash', query);
+      const transactions = await this.elasticService.getList('operations', 'txHash', query);
 
-    return transactions;
+      return transactions;
+    } catch (error) {
+      this.logger.error(`Failed to get txDetails`);
+      this.logger.error(error);
+
+      return [];
+    }
   }
 }

--- a/libs/common/src/services/indexer/indexer.service.ts
+++ b/libs/common/src/services/indexer/indexer.service.ts
@@ -96,4 +96,26 @@ export class IndexerService {
 
     return logs;
   }
+
+  @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
+  public async getTxCallerPairs(txHashes: string[]) {
+    const query = ElasticQuery.create()
+      .withPagination({ from: 0, size: 10000 })
+      .withMustCondition([
+        QueryType.Should(txHashes.map(txHash => new MatchQuery("_id", txHash))),
+      ]);
+
+    const txCallerPairs: {
+      tx: any; caller: any
+    }[] = [];
+
+    await this.elasticService.getScrollableList('operations', 'txHash', query, async (transactions) => {
+      const txCallerPairsTemp = transactions.map(transaction => ({ tx: transaction.txHash, caller: transaction.sender }));
+      txCallerPairs.push(...txCallerPairsTemp);
+    }, {
+      scrollTimeout: '10m',
+    });
+
+    return txCallerPairs;
+  }
 }

--- a/libs/common/src/services/indexer/indexer.service.ts
+++ b/libs/common/src/services/indexer/indexer.service.ts
@@ -98,24 +98,15 @@ export class IndexerService {
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
-  public async getTxCallerPairs(txHashes: string[]) {
+  public async getTxDetails(txHashes: string[]) {
     const query = ElasticQuery.create()
       .withPagination({ from: 0, size: 10000 })
       .withMustCondition([
         QueryType.Should(txHashes.map(txHash => new MatchQuery("_id", txHash))),
       ]);
 
-    const txCallerPairs: {
-      tx: any; caller: any
-    }[] = [];
+    const transactions = await this.elasticService.getList('operations', 'txHash', query);
 
-    await this.elasticService.getScrollableList('operations', 'txHash', query, async (transactions) => {
-      const txCallerPairsTemp = transactions.map(transaction => ({ tx: transaction.txHash, caller: transaction.sender }));
-      txCallerPairs.push(...txCallerPairsTemp);
-    }, {
-      scrollTimeout: '10m',
-    });
-
-    return txCallerPairs;
+    return transactions;
   }
 }

--- a/libs/common/src/services/multiversx.api/multiversx.api.service.ts
+++ b/libs/common/src/services/multiversx.api/multiversx.api.service.ts
@@ -18,7 +18,7 @@ export class MultiversXApiService {
   public async getToken(identifier: string): Promise<Token | null> {
     return await this.cacheService.getOrSet(
       CacheInfo.Token(identifier).key,
-      () => this.getTokenRaw(identifier),
+      async () => await this.getTokenRaw(identifier),
       CacheInfo.Token(identifier).ttl,
     );
   }

--- a/libs/common/src/services/multiversx.api/multiversx.api.service.ts
+++ b/libs/common/src/services/multiversx.api/multiversx.api.service.ts
@@ -42,7 +42,7 @@ export class MultiversXApiService {
   public async getContractDeployInfo(address: string): Promise<{ deployTxHash?: string, deployedAt?: number }> {
     return await this.cacheService.getOrSet(
       CacheInfo.ContractDeployInfo(address).key,
-      () => this.getContractDeployInfoRaw(address),
+      async () => await this.getContractDeployInfoRaw(address),
       CacheInfo.ContractDeployInfo(address).ttl,
     );
   }


### PR DESCRIPTION
## Type

- [ ] Bug

## Problem setting
- `wrong` caller address for some events 

## Proposed Changes

- get real caller address from `Elastic Search`

## How to test
- `dex-screener-adapter/events?fromBlock=...&toBlock=...` should display accurate data about caller address (` maker `)
